### PR TITLE
Add Feedlr::Error::ServiceUnavailableError

### DIFF
--- a/lib/feedlr/error.rb
+++ b/lib/feedlr/error.rb
@@ -13,7 +13,8 @@ module Feedlr
           401 => Feedlr::Error::Unauthorized,
           403 => Feedlr::Error::Forbidden,
           404 => Feedlr::Error::NotFound,
-          500 => Feedlr::Error::InternalServerError
+          500 => Feedlr::Error::InternalServerError,
+          503 => Feedlr::Error::ServiceUnavailableError
         }
       end
     end
@@ -48,6 +49,9 @@ module Feedlr
 
     # Raised when Feedlr returns the HTTP status status_code 500
     class InternalServerError < ServerError; end
+
+    # Raised when Feedlr returns the HTTP status status_code 503
+    class ServiceUnavailableError < ServerError; end
 
     # Raised when the request times out
     class RequestTimeout < self; end


### PR DESCRIPTION
Hi @khelll 

This PR is going to support the case below.

```
cursor=#<Feedlr::Base errorCode=503 errorId="ap7-sv2.2014101600.3589028" errorMessage="too many requests, try again later">
```
